### PR TITLE
Replace zendframework/zend-filter by laminas/laminas-filter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,9 @@
         "php": ">=5.4",
         "laminas/laminas-filter": "2.*"
     },
+    "require-dev": {
+        "phpunit/phpunit": "~4.2"
+    },
     "autoload": {
         "psr-4": {
             "Conversio\\": "library/",

--- a/composer.json
+++ b/composer.json
@@ -12,11 +12,7 @@
     ],
     "require": {
         "php": ">=5.4",
-        "zendframework/zend-filter": "~2.2"
-    },
-    "require-dev": {
-        "phpunit/phpunit": "~4.2",
-        "satooshi/php-coveralls": "dev-master"
+        "laminas/laminas-filter": "2.*"
     },
     "autoload": {
         "psr-4": {

--- a/library/Adapter/AbstractOptionsEnabledAdapter.php
+++ b/library/Adapter/AbstractOptionsEnabledAdapter.php
@@ -11,7 +11,7 @@ namespace Conversio\Adapter;
 use Conversio\Conversion;
 use Conversio\Exception;
 use Conversio\ConversionAlgorithmInterface;
-use Zend\Stdlib\AbstractOptions;
+use Laminas\Stdlib\AbstractOptions;
 
 /**
  * Class AbstractOptionsEnabledAdapter

--- a/library/Adapter/Options/OptionsMap.php
+++ b/library/Adapter/Options/OptionsMap.php
@@ -9,8 +9,8 @@
 namespace Conversio\Adapter\Options;
 
 use Conversio\Exception;
-use Zend\Stdlib\AbstractOptions;
-use Zend\Stdlib\ArrayUtils;
+use Laminas\Stdlib\AbstractOptions;
+use Laminas\Stdlib\ArrayUtils;
 
 /**
  * Class OptionsMap

--- a/library/Conversion.php
+++ b/library/Conversion.php
@@ -8,10 +8,10 @@
  */
 namespace Conversio;
 
+use Laminas\Filter\AbstractFilter;
+use Laminas\Stdlib\AbstractOptions;
+use Laminas\Stdlib\ArrayUtils;
 use Traversable;
-use Zend\Filter\AbstractFilter;
-use Zend\Stdlib\AbstractOptions;
-use Zend\Stdlib\ArrayUtils;
 
 /**
  * Class Conversion
@@ -215,7 +215,7 @@ class Conversion extends AbstractFilter
             ));
         }
         foreach ($options as $key => $value) {
-            if ($key == 'options') {
+            if ($key === 'options') {
                 $key = 'adapterOptions';
             }
             $method = 'set' . ucfirst($key);


### PR DESCRIPTION
As Zend Filter is abandoned and not compatible with PHP 8, this PR replaces it with `laminas/laminas-filter`.